### PR TITLE
Expo 40 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "url": "git+https://github.com/xcarpentier/rn-pdf-reader-js.git"
   },
   "peerDependencies": {
-    "expo": ">= 33.0.x < 37.0.x",
+    "expo": ">= 33.0.x < 41.0.x",
     "expo-constants": ">= 5.0.0 < 9.x",
     "expo-file-system": ">= 5.0.0 < 9.x",
     "react": "16.x",
     "react-native": "*",
-    "react-native-webview": ">= 7.0.5 < 8.x"
+    "react-native-webview": ">= 7.0.5 < 12.x"
   },
   "dependencies": {
     "buffer": "5.1.0",


### PR DESCRIPTION
Updated package.json to Expo 40, as it seems to run fine on there with no issues, barring the package json preventing it from installing.